### PR TITLE
Fix gem name at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Segmented by the worker (index of the worker):
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'yabeda-puma'
+gem 'yabeda-puma-plugin'
 ```
 
 And then execute:


### PR DESCRIPTION
I was trying to use this plugin, but when I was starting my server it was raising error:

```
gems/puma-3.11.4/lib/puma/plugin.rb:48:in `rescue in find': Unable to find plugin: yabeda (Puma::UnknownPlugin)
```

After exploring the [example prometheus project](https://github.com/yabeda-rb/example-prometheus) I found that it was using a different gem https://github.com/yabeda-rb/example-prometheus/blob/64a67c0e000f8b2516aac6bb2f0eb21f634a3ea9/rails_app/Gemfile#L24

```
gem "yabeda-puma-plugin"
```

After put this gem at my gemfile, it works as expected.

Anyone knows what was this gem `yabeda-puma`?