### PR TITLE
Fix undefined method in TCP socket

### DIFF
--- a/lib/yabeda/puma/plugin/statistics/fetcher.rb
+++ b/lib/yabeda/puma/plugin/statistics/fetcher.rb
@@ -9,23 +9,26 @@ module Yabeda
           def self.call
             control_url = Yabeda::Puma::Plugin.control_url
 
-            if control_url.start_with? "unix://"
+            body = if control_url.start_with? "unix://"
               path = control_url.gsub("unix://", '')
-              sock = Socket.unix(path)
+              Socket.unix(path, &socket_block)
             elsif control_url.start_with? "tcp://"
               host, port = control_url.match(/^tcp:\/\/([a-z0-9\-._~%]+):([0-9]+)/).captures
-
-              sock = Socket.tcp(host, port)
+              Socket.tcp(host, port, &socket_block)
             else
-              raise ArgumentError("Unknown puma control url type #{control_url}")
-            end
-
-            body = sock do |socket|
-              socket << "GET /stats?token=#{Yabeda::Puma::Plugin.control_auth_token} HTTP/1.0\r\n\r\n"
-              socket.read
+              raise ArgumentError.new("Unknown puma control url type #{control_url}")
             end
 
             JSON.parse(body.split("\n").last)
+          end
+
+          private
+
+          def self.socket_block
+            Proc.new do |s|
+              s << "GET /stats?token=#{Yabeda::Puma::Plugin.control_auth_token} HTTP/1.0\r\n\r\n"
+              s.read
+            end
           end
         end
       end

--- a/spec/support/http_server.rb
+++ b/spec/support/http_server.rb
@@ -1,0 +1,25 @@
+require 'socket'
+
+class HttpServer
+  def initialize(server, json)
+    @server = server
+    @json   = json
+  end
+
+  def start
+    while session = server.accept
+      request = session.gets
+
+      session.print "HTTP/1.1 200\r\n"
+      session.print "Content-Type: application/json\r\n"
+      session.print "\r\n"
+      session.print json
+
+      session.close
+    end
+  end
+
+  private
+
+  attr_reader :server, :json
+end

--- a/spec/yabeda/puma/plugin/statistics/fetcher_spec.rb
+++ b/spec/yabeda/puma/plugin/statistics/fetcher_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+require 'support/http_server'
+require 'yabeda/puma/plugin/statistics/fetcher'
+
+RSpec.describe Yabeda::Puma::Plugin::Statistics::Fetcher do
+  describe '#call' do
+    let(:fetcher) { described_class }
+    let(:metrics) { {metric_1: 1, metric_2: 2} }
+
+    context 'when unix socket' do
+      let(:unix_addr) { '/tmp/sock_test' }
+      
+      before { Yabeda::Puma::Plugin.control_url = "unix://#{unix_addr}" }
+
+      after { system("rm #{unix_addr}") }
+
+      it do
+        server = HttpServer.new(UNIXServer.new(unix_addr), metrics.to_json)
+        
+        Thread.new { server.start }
+
+        expect(fetcher.call).to eq metrics.transform_keys(&:to_s)
+      end
+    end
+
+    context 'when tcp socket' do
+      let(:port) { 4000 }
+
+      before { Yabeda::Puma::Plugin.control_url = "tcp://0.0.0.0:#{port}" }
+
+      it do
+        server = HttpServer.new(TCPServer.new(port), metrics.to_json)
+        
+        Thread.new { server.start }
+
+        expect(fetcher.call).to eq metrics.transform_keys(&:to_s)
+      end
+    end
+
+    context 'when invalid address' do
+      let(:addr) { 'invalid_addr' }
+
+      before { Yabeda::Puma::Plugin.control_url = addr }
+
+      it do
+        expect{fetcher.call}.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi! 
Problem ```undefined method 'sock' for Yabeda::Puma::Plugin::Statistics::Fetcher::Class``` appeared after update to 0.2.0 version. Seems like it is because of initialization ```Socket``` in variable.
Linked with https://github.com/yabeda-rb/yabeda-puma-plugin/issues/6