### PR TITLE
Aggregate all metrics with "most recent"

### DIFF
--- a/lib/puma/plugin/yabeda.rb
+++ b/lib/puma/plugin/yabeda.rb
@@ -15,15 +15,15 @@ Puma::Plugin.create do
     Yabeda.configure do
       group :puma
 
-      gauge :backlog, tags: %i[index], comment: 'Number of established but unaccepted connections in the backlog'
-      gauge :running, tags: %i[index], comment: 'Number of running worker threads'
-      gauge :pool_capacity, tags: %i[index], comment: 'Number of allocatable worker threads'
-      gauge :max_threads, tags: %i[index], comment: 'Maximum number of worker threads'
+      gauge :backlog, tags: %i[index], comment: 'Number of established but unaccepted connections in the backlog', aggregation: :most_recent
+      gauge :running, tags: %i[index], comment: 'Number of running worker threads', aggregation: :most_recent
+      gauge :pool_capacity, tags: %i[index], comment: 'Number of allocatable worker threads', aggregation: :most_recent
+      gauge :max_threads, tags: %i[index], comment: 'Maximum number of worker threads', aggregation: :most_recent
 
       if clustered
-        gauge :workers, comment: 'Number of configured workers'
-        gauge :booted_workers, comment: 'Number of booted workers'
-        gauge :old_workers, comment: 'Number of old workers'
+        gauge :workers, comment: 'Number of configured workers', aggregation: :most_recent
+        gauge :booted_workers, comment: 'Number of booted workers', aggregation: :most_recent
+        gauge :old_workers, comment: 'Number of old workers', aggregation: :most_recent
       end
 
       collect do


### PR DESCRIPTION
This change updates all of the gauges to include "most recent"
aggregation. This is safe for single- and multi-process mode because
only the DirectFileStore from prometheus-client handles the aggregation
option -- there is no aggregation to be done in single-process mode.

fixes #15