### PR TITLE
Support phased restarts with standalone exporter

### DIFF
--- a/lib/puma/plugin/yabeda_prometheus.rb
+++ b/lib/puma/plugin/yabeda_prometheus.rb
@@ -27,23 +27,38 @@ Puma::Plugin.create do
     port = Integer(ENV.fetch('PROMETHEUS_EXPORTER_PORT', uri.port))
     path = ENV.fetch('PROMETHEUS_EXPORTER_PATH', uri.path)
 
-    events.on_booted do
+    msg = "Yabeda Prometheus metrics exporter on http://#{host}:#{port}#{path}"
+
+    metrics = nil
+
+    start_server = -> {
       app = Yabeda::Prometheus::Exporter.rack_app(Yabeda::Prometheus::Exporter, path: path)
-
-      metrics = Puma::Server.new app, events
-      metrics.min_threads = 0
-      metrics.max_threads = 1
-
-      events.log "* Starting Yabeda Prometheus metrics exporter on http://#{host}:#{port}#{path}"
-      metrics.add_tcp_listener host, port
-
-      events.register(:state) do |state|
-        if %i[halt restart stop].include?(state)
-          metrics.stop(true) unless metrics.shutting_down?
-        end
+      metrics = Puma::Server.new(app).tap do |server|
+        server.min_threads = 0
+        server.max_threads = 1
+        server.add_tcp_listener host, port
+        server.run
       end
+    }
 
-      metrics.run
+    events.on_stopped do
+      unless metrics&.shutting_down?
+        events.log "* Stopping #{msg}"
+        metrics.stop(true)
+      end
+    end
+
+    events.on_restart do
+      events.log "* Restarting #{msg}"
+      metrics.stop(true)
+      start_server.call
+    end
+
+    events.on_booted do
+      unless metrics&.running
+        events.log "* Starting #{msg}"
+        start_server.call
+      end
     end
   end
 end

--- a/spec/configs/puma_standalone.rb
+++ b/spec/configs/puma_standalone.rb
@@ -1,0 +1,15 @@
+require 'puma/plugin/yabeda'
+require 'puma/plugin/yabeda_prometheus'
+require 'yabeda'
+require 'yabeda/prometheus'
+
+workers 2
+threads 1, 1
+activate_control_app
+plugin 'yabeda'
+plugin 'yabeda_prometheus'
+prometheus_exporter_url "tcp://127.0.0.1:9394/metrics"
+
+before_fork do
+  Yabeda.configure!
+end

--- a/spec/configs/standalone.ru
+++ b/spec/configs/standalone.ru
@@ -1,0 +1,3 @@
+require 'rack/lobster'
+use Rack::ShowExceptions
+run Rack::Lobster.new

--- a/spec/integration/standalone_exporter_spec.rb
+++ b/spec/integration/standalone_exporter_spec.rb
@@ -1,0 +1,63 @@
+require "net/http"
+
+RSpec.describe "Standalone Prometheus Exporter" do
+  before(:each) do
+    cmd = <<~EOF
+      bundle exec puma \
+        -b tcp://127.0.0.1:9222 \
+        -C spec/configs/puma_standalone.rb \
+        spec/configs/standalone.ru
+    EOF
+    @io = IO.popen cmd, err: [:child, :out]
+    @pid = @io.pid
+    sleep 0.5
+  end
+
+  after(:each) do
+    Process.kill "INT", @pid 
+    Process.wait @pid
+  end
+
+  it 'serves app on configured port' do
+    res = get 9222, "/"
+    expect(res.body).to match(/Lobstericious/)
+  end
+
+  it 'serves metrics on exporter url' do
+    res = get 9394, "/metrics"
+    expect(res.body).to match(/^# TYPE puma_workers gauge/)
+  end
+
+  it 'serves metrics after hot restart' do
+    Process.kill("USR2", @pid)
+    sleep 0.5
+    res = get 9394, "/metrics"
+    expect(res.body).to match(/^# TYPE puma_workers gauge/)
+  end
+
+  it 'serves metrics after phased restart' do
+    Process.kill("USR1", @pid)
+    sleep 0.5
+    res = get 9394, "/metrics"
+    expect(res.body).to match(/^# TYPE puma_workers gauge/)
+  end
+
+  def get(port, path = "/")
+    retries = 3
+    begin
+      Net::HTTP.start("127.0.0.1", port, open_timeout: 3) do |http|
+        req = Net::HTTP::Get.new path
+        return http.request req
+      end
+    rescue Errno::ECONNREFUSED
+      if retries > 0
+        retries -= 1
+        sleep 1
+        retry
+      else
+        raise "Connection failed too many times for http://127.0.0.1:#{port}#{path}"
+      end
+    end
+    nil
+  end
+end

--- a/yabeda-puma-plugin.gemspec
+++ b/yabeda-puma-plugin.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rack"
+  spec.add_development_dependency "yabeda-prometheus", "~> 0.8"
 end


### PR DESCRIPTION
Addresses #22 

This change adds some additional tests to cover clustered mode with the
standalone exporter. The phased restart example fails without the patch
to the exporter, which modifies it to handle the events differently:

 - The metrics server variable is moved outside of the on_booted handler
   so it is not created separately in the forked workers
 - The on_booted handler safely checks whether the server is running
   before attempting to start
 - The on_stopped and on_restart events are caught and issue a
   synchronous stop, rather than the previous state hook, which does not
   signal restart

The construction is a little odd, with the start_server lambda assigning
the metrics server instance, but I found the behavior quite fickle when
trying to reuse an instance. This was the most concise solution I could
come up with.