### PR TITLE
Further Puma 6 fix and fix for #26

### DIFF
--- a/lib/puma/plugin/yabeda_prometheus.rb
+++ b/lib/puma/plugin/yabeda_prometheus.rb
@@ -33,7 +33,7 @@ Puma::Plugin.create do
     path = ENV.fetch('PROMETHEUS_EXPORTER_PATH', uri.path)
 
     server = nil
-    logger = events
+    logger = nil
     banner = "Yabeda Prometheus metrics exporter on http://#{host}:#{port}#{path}"
 
     create_server = -> {
@@ -69,7 +69,7 @@ Puma::Plugin.create do
     if events.respond_to?(:on_stopped) && events.respond_to?(:on_restart)
 
       events.on_stopped do
-        unless server&.shutting_down?
+        if server && !server.shutting_down?
           logger.log "* Stopping #{banner}"
           server.stop(true)
         end


### PR DESCRIPTION
logger by default is `events` which doesn't work in Puma 6, it fails with: `undefined method `log' for #<Puma::Events:0x00007f905c558720>`