### PR TITLE
Extract initialization of Puma metrics

### DIFF
--- a/lib/puma/plugin/yabeda.rb
+++ b/lib/puma/plugin/yabeda.rb
@@ -12,29 +12,7 @@ Puma::Plugin.create do
       puma.control_auth_token = launcher.options[:control_auth_token]
     end
 
-    Yabeda.configure do
-      group :puma
-
-      gauge :backlog, tags: %i[index], comment: 'Number of established but unaccepted connections in the backlog', aggregation: :most_recent
-      gauge :running, tags: %i[index], comment: 'Number of running worker threads', aggregation: :most_recent
-      gauge :pool_capacity, tags: %i[index], comment: 'Number of allocatable worker threads', aggregation: :most_recent
-      gauge :max_threads, tags: %i[index], comment: 'Maximum number of worker threads', aggregation: :most_recent
-
-      if clustered
-        gauge :workers, comment: 'Number of configured workers', aggregation: :most_recent
-        gauge :booted_workers, comment: 'Number of booted workers', aggregation: :most_recent
-        gauge :old_workers, comment: 'Number of old workers', aggregation: :most_recent
-      end
-
-      collect do
-        require 'yabeda/puma/plugin/statistics/fetcher'
-        stats = Yabeda::Puma::Plugin::Statistics::Fetcher.call
-        require 'yabeda/puma/plugin/statistics/parser'
-        Yabeda::Puma::Plugin::Statistics::Parser.new(clustered: clustered, data: stats).call.each do |item|
-          send("puma_#{item[:name]}").set(item[:labels], item[:value])
-        end
-      end
-    end
+    Yabeda::Puma::Plugin.install!(clustered: clustered)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before(:all) do
+    Yabeda.configure!
+  end
 end

--- a/spec/yabeda/puma/plugin_spec.rb
+++ b/spec/yabeda/puma/plugin_spec.rb
@@ -4,4 +4,61 @@ RSpec.describe Yabeda::Puma::Plugin do
   it "has a version number" do
     expect(Yabeda::Puma::Plugin::VERSION).not_to be nil
   end
+
+  describe '.install!' do
+    let(:collectors) { [] }
+    let(:configurators) { [] }
+
+    before do
+      allow(Yabeda).to receive(:collectors).and_return(collectors)
+      allow(Yabeda).to receive(:configurators).and_return(configurators)
+    end
+
+    it 'adds a collector and a configurator' do
+      expect do
+        described_class.install!
+      end.to change { Yabeda.collectors.size }.by(1)
+        .and change { Yabeda.configurators.size }.by(1)
+    end
+
+    it 'collects Puma metrics for single mode' do
+      described_class.install!
+
+      yabeda_double = double('Yabeda')
+
+      expect(yabeda_double).to receive(:group).with(:puma)
+
+      expect(yabeda_double).to receive(:gauge).with(:backlog, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:running, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:pool_capacity, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:max_threads, any_args)
+
+      expect(yabeda_double).to receive(:collect)
+
+      configurator = configurators.first.last
+      yabeda_double.instance_eval(&configurator)
+    end
+
+    it 'collects clustered Puma metrics' do
+      described_class.install!(clustered: true)
+
+      yabeda_double = double('Yabeda')
+
+      expect(yabeda_double).to receive(:group).with(:puma)
+
+      expect(yabeda_double).to receive(:gauge).with(:backlog, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:running, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:pool_capacity, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:max_threads, any_args)
+
+      expect(yabeda_double).to receive(:gauge).with(:workers, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:booted_workers, any_args)
+      expect(yabeda_double).to receive(:gauge).with(:old_workers, any_args)
+
+      expect(yabeda_double).to receive(:collect)
+
+      configurator = configurators.first.last
+      yabeda_double.instance_eval(&configurator)
+    end
+  end
 end


### PR DESCRIPTION
Moves the initialization of Puma metrics to a method that can be called on demand outside of a Puma plugin, for instance, when you have an exporter that runs on a separate process as the app and the exporter merely reads the metrics collected by the app that generates the metrics.

Resolves yabeda-rb/yabeda-puma-plugin#29

The method can be invoked by doing
```rb
require 'yabeda/puma/plugin'

Yabeda::Puma::Plugin.tap do |puma|
  puma.control_url = # your_control_url
  puma.control_auth_token = # your_control_auth_token
end

Yabeda::Puma::Plugin.install! clustered: # are you running Puma in clustered mode?
```