### PR TITLE
Add `requests_count` measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Segmented by the worker (index of the worker):
  - `puma_running` - the number of running threads (spawned threads) for any puma worker
  - `puma_max_threads` - preconfigured maximum number of worker threads
  - `puma_backlog` - the number of backlog threads, the number of connections in that worker's "todo" set waiting for a worker thread.
+ - `puma_requests_count` - the number of requests a worker has served since starting.
 
 ## Installation
 

--- a/lib/puma/plugin/yabeda.rb
+++ b/lib/puma/plugin/yabeda.rb
@@ -19,6 +19,7 @@ Puma::Plugin.create do
       gauge :running, tags: %i[index], comment: 'Number of running worker threads', aggregation: :most_recent
       gauge :pool_capacity, tags: %i[index], comment: 'Number of allocatable worker threads', aggregation: :most_recent
       gauge :max_threads, tags: %i[index], comment: 'Maximum number of worker threads', aggregation: :most_recent
+      gauge :requests_count, tags: %i[index], comment: 'Number of requests this worker has served since starting', aggregation: :most_recent
 
       if clustered
         gauge :workers, comment: 'Number of configured workers', aggregation: :most_recent
@@ -37,4 +38,3 @@ Puma::Plugin.create do
     end
   end
 end
-

--- a/lib/yabeda/puma/plugin/statistics.rb
+++ b/lib/yabeda/puma/plugin/statistics.rb
@@ -2,7 +2,7 @@ module Yabeda
   module Puma
     module Plugin
       module Statistics
-        METRICS = [:backlog, :running, :pool_capacity, :max_threads]
+        METRICS = [:backlog, :running, :pool_capacity, :max_threads, :requests_count]
         CLUSTERED_METRICS = [:booted_workers, :old_workers, :workers]
       end
     end

--- a/spec/yabeda/puma/plugin/statistics/parser_spec.rb
+++ b/spec/yabeda/puma/plugin/statistics/parser_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
           "worker_status"=>[
             {"pid"=>13, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-03-31T13:04:28Z",
              "last_status"=>{
-              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5
+              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "requests_count" => 5,
             }},
             {"pid"=>17, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-03-31T13:04:28Z",
              "last_status"=>{
-              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5
+              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "requests_count" => 5,
             }
             }
           ]
@@ -36,11 +36,13 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
             { name: 'running', labels: {index: 0}, value: 5 },
             { name: 'pool_capacity', labels: {index: 0}, value: 5 },
             { name: 'max_threads', labels: {index: 0}, value: 5 },
+            { name: 'requests_count', labels: {index: 0}, value: 5},
 
             { name: 'backlog', labels: {index: 1}, value: 0 },
             { name: 'running', labels: {index: 1}, value: 5 },
             { name: 'pool_capacity', labels: {index: 1}, value: 5 },
-            { name: 'max_threads', labels: {index: 1}, value: 5 }
+            { name: 'max_threads', labels: {index: 1}, value: 5 },
+            { name: 'requests_count', labels: {index: 1}, value: 5},
           ]
         )
       end

--- a/spec/yabeda/puma/plugin/statistics/parser_spec.rb
+++ b/spec/yabeda/puma/plugin/statistics/parser_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
           "worker_status"=>[
             {"pid"=>13, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-03-31T13:04:28Z",
              "last_status"=>{
-              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "busy_threads"=>4, "requests_count" => 5,
+              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "busy_threads"=>4, "requests_count"=>5,
             }},
             {"pid"=>17, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-03-31T13:04:28Z",
              "last_status"=>{
-              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "busy_threads"=>4", requests_count" => 5,
+              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "busy_threads"=>4, "requests_count"=>5,
             }
             }
           ]


### PR DESCRIPTION
Summary
========

Closes: https://github.com/yabeda-rb/yabeda-puma-plugin/issues/19

Expose the number of requests a puma worker has processed.

Context
========

Since https://github.com/puma/puma/pull/2106, puma workers keep track of how many requests they have processed. This exposes [Puma's `requests_count` stat](https://github.com/ylecuyer/puma/blob/063b7c8738826d5e1a157f0a741381dc02fcefcb/lib/puma/single.rb#L23) via the yabeda-puma-plugin. 

Examples
--------

Standalone mode
```
[...snip...]
# TYPE puma_requests_count gauge
# HELP puma_requests_count Number of requests this worker has served since starting
puma_requests_count{index="0"} 103.0
[...snip...]
```

Clustered mode (4 workers) 
```
[...snip...]
# TYPE puma_requests_count gauge
# HELP puma_requests_count Number of requests this worker has served since starting
puma_requests_count{index="0"} 82.0
puma_requests_count{index="1"} 76.0
puma_requests_count{index="2"} 61.0
puma_requests_count{index="3"} 44.0
[...snip...]
```