### PR TITLE
Add `busy_threads` metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Works as the Puma plugin and provides following metrics:
 Segmented by the worker (index of the worker):
  - `puma_pool_capacity` - the capacity of each worker: the number of requests that the server is capable of taking right now. More details are [here](https://github.com/puma/puma/blob/0f8b10737e36fc24cdd572f76a739659b5fad9cb/lib/puma/server.rb#L167).
  - `puma_running` - the number of running threads (spawned threads) for any puma worker
+ - `puma_busy_threads` - the number of busy threads (`running threads` - `how many threads are waiting to receive work` + `how many requests are waiting for a thread to pick them up`)
  - `puma_max_threads` - preconfigured maximum number of worker threads
  - `puma_backlog` - the number of backlog threads, the number of connections in that worker's "todo" set waiting for a worker thread.
 

--- a/lib/puma/plugin/yabeda.rb
+++ b/lib/puma/plugin/yabeda.rb
@@ -17,6 +17,7 @@ Puma::Plugin.create do
 
       gauge :backlog, tags: %i[index], comment: 'Number of established but unaccepted connections in the backlog', aggregation: :most_recent
       gauge :running, tags: %i[index], comment: 'Number of running worker threads', aggregation: :most_recent
+      gauge :busy_threads, tags: %i[index], comment: 'Number of busy worker threads', aggregation: :most_recent
       gauge :pool_capacity, tags: %i[index], comment: 'Number of allocatable worker threads', aggregation: :most_recent
       gauge :max_threads, tags: %i[index], comment: 'Maximum number of worker threads', aggregation: :most_recent
 

--- a/lib/yabeda/puma/plugin/statistics.rb
+++ b/lib/yabeda/puma/plugin/statistics.rb
@@ -2,7 +2,7 @@ module Yabeda
   module Puma
     module Plugin
       module Statistics
-        METRICS = [:backlog, :running, :pool_capacity, :max_threads]
+        METRICS = [:backlog, :running, :pool_capacity, :max_threads, :busy_threads]
         CLUSTERED_METRICS = [:booted_workers, :old_workers, :workers]
       end
     end

--- a/spec/yabeda/puma/plugin/statistics/parser_spec.rb
+++ b/spec/yabeda/puma/plugin/statistics/parser_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
           "worker_status"=>[
             {"pid"=>13, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-03-31T13:04:28Z",
              "last_status"=>{
-              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5
+              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "busy_threads"=>4
             }},
             {"pid"=>17, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-03-31T13:04:28Z",
              "last_status"=>{
-              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5
+              "backlog"=>0, "running"=>5, "pool_capacity"=>5, "max_threads"=>5, "busy_threads"=>4
             }
             }
           ]
@@ -36,11 +36,13 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
             { name: 'running', labels: {index: 0}, value: 5 },
             { name: 'pool_capacity', labels: {index: 0}, value: 5 },
             { name: 'max_threads', labels: {index: 0}, value: 5 },
+            { name: 'busy_threads', labels: {index: 0}, value: 4 },
 
             { name: 'backlog', labels: {index: 1}, value: 0 },
             { name: 'running', labels: {index: 1}, value: 5 },
             { name: 'pool_capacity', labels: {index: 1}, value: 5 },
-            { name: 'max_threads', labels: {index: 1}, value: 5 }
+            { name: 'max_threads', labels: {index: 1}, value: 5 },
+            { name: 'busy_threads', labels: {index: 1}, value: 4 }
           ]
         )
       end
@@ -50,7 +52,7 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
     context 'when puma is unclustered' do
       let(:clustered) { false }
       let(:data) do
-        {"backlog"=>0, "running"=>5, "pool_capacity"=>4, "max_threads"=>5}
+        {"backlog"=>0, "running"=>5, "pool_capacity"=>4, "max_threads"=>5, "busy_threads"=>4}
       end
 
       it do
@@ -59,7 +61,8 @@ RSpec.describe Yabeda::Puma::Plugin::Statistics::Parser do
             { name: 'backlog', labels: {index: 0}, value: 0 },
             { name: 'running', labels: {index: 0}, value: 5 },
             { name: 'pool_capacity', labels: {index: 0}, value: 4 },
-            { name: 'max_threads', labels: {index: 0}, value: 5 }
+            { name: 'max_threads', labels: {index: 0}, value: 5 },
+            { name: 'busy_threads', labels: {index: 0}, value: 4 }
           ]
         )
       end


### PR DESCRIPTION
Puma 6.6 added a new busy_threads metric (https://github.com/puma/puma/pull/3517).
This PR exposes it via yabeda.