### PR TITLE
Support for Puma 7.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         include:
           - ruby: "3.3"
+            puma: "7"
+          - ruby: "3.3"
             puma: "6"
           - ruby: "3.2"
             puma: "6"
@@ -28,6 +30,8 @@ jobs:
             puma: "5"
           - ruby: "2.7"
             puma: "4"
+    env:
+      PUMA_VERSION: ${{ matrix.puma }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -35,4 +39,4 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: Run RSpec
-        run: bundle exec rspec
+        run: bundle install && bundle exec rspec

--- a/spec/integration/clustered_spec.rb
+++ b/spec/integration/clustered_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Yabeda::Puma::Plugin do
       @events = Puma::Events.strings
     end
 
-    @events.on_booted { @ready << "!" }
+    after_booted = @events.respond_to?(:after_booted) ? :after_booted : :on_booted
+    @events.public_send(after_booted) { @ready << "!" }
   end
 
   after(:each) do


### PR DESCRIPTION
Puma 7.0.0 was recently released and renamed the callback hooks.

See https://github.com/puma/puma/blob/master/History.md#700

I'm not sure how you feel about :public_send, but that felt better than duplicating the blocks of actual callable code. If you disagree, I'm happy to tweak it.